### PR TITLE
Ensure the Swift version is correct so we can pass linting

### DIFF
--- a/Berbix.podspec
+++ b/Berbix.podspec
@@ -27,4 +27,6 @@ to get started.
   s.public_header_files = "Berbix.xcframework/*/Berbix.framework/Headers/*.h"
   s.source_files = "Berbix.xcframework/*/Berbix.framework/Headers/*.h"
   s.vendored_frameworks = "Berbix.xcframework"
+
+  s.swift_version = "4.2"
 end


### PR DESCRIPTION
This was removed in the `arm64` PR before we were linting on CI. Now we know that we must explicitly specify the Swift version.