### PR TITLE
Delete legacy framework before linting

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -55,6 +55,7 @@ jobs:
         name: Check-out source
       - name: Lint & Deploy Podspec
         run: |
+          rm -rf Berbix.framework # Remove legacy framework
           pod repo add berbix https://github.com/berbix/berbix-ios-distribution.git
           pod lib lint --verbose
           pod repo push berbix Berbix.podspec

--- a/Berbix.podspec
+++ b/Berbix.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'Berbix'
-  s.version          = '3.0.2'
+  s.version          = '3.0.1'
   s.summary          = 'Berbix iOS SDK for rendering the Berbix Verify flow'
 
   s.description      = <<-DESC
@@ -24,8 +24,6 @@ to get started.
   s.platform = :ios, "11.0"
   s.ios.deployment_target = '11.0'
 
-  s.public_header_files = "Berbix.xcframework/*/Berbix.framework/Headers/*.h"
-  s.source_files = "Berbix.xcframework/*/Berbix.framework/Headers/*.h"
   s.vendored_frameworks = "Berbix.xcframework"
 
   s.swift_version = "4.2"


### PR DESCRIPTION
The problem was that `pod lib lint` was failing on CI. It was finally tracked down to the legacy `.framework` contained in the root of this repository. Rather than remove that file, we delete it on CI before the run.

Alternative fix for #8 