### PR TITLE
Fix berbix repo in CI

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -56,6 +56,6 @@ jobs:
       - name: Lint & Deploy Podspec
         run: |
           rm -rf Berbix.framework # Remove legacy framework
-          pod repo add berbix https://github.com/berbix/berbix-ios-distribution.git
+          pod repo add berbix git@github.com:berbix/berbix-ios-spec.git
           pod lib lint --verbose
           pod repo push berbix Berbix.podspec


### PR DESCRIPTION
Although the release is performed from this repository, the results of the work are contained in `berbix-ios-spec`. 

Now this mistake becomes harder to make!